### PR TITLE
fix:配置目录无wxid标识，导致无用户标识

### DIFF
--- a/lib/pages/data_management_page.dart
+++ b/lib/pages/data_management_page.dart
@@ -111,6 +111,8 @@ class _DataManagementPageState extends State<DataManagementPage> {
         final parentDirName = pathParts[pathParts.length - 2];
         if (parentDirName.startsWith('wxid_')) {
           wxidName = parentDirName;
+        }else{
+          wxidName="wxid_$parentDirName";
         }
       }
       


### PR DESCRIPTION
最新版本目录已经无wxid的标识，会导致找不到数据库目录

如此issue
https://github.com/ycccccccy/echotrace/issues/12