### PR TITLE
修复聊天记录页面，联系人/具体记录显示不全的问题

### DIFF
--- a/lib/models/chat_session.dart
+++ b/lib/models/chat_session.dart
@@ -67,28 +67,33 @@ class ChatSession {
       username: _stringValue(['username', 'user_name', 'userName']),
       type: _intValue(['type']),
       unreadCount: _intValue(['unread_count', 'unreadCount']),
-      unreadFirstMsgSrvId:
-          _intValue(['unread_first_msg_srv_id', 'unreadFirstMsgSrvId']),
+      unreadFirstMsgSrvId: _intValue([
+        'unread_first_msg_srv_id',
+        'unreadFirstMsgSrvId',
+      ]),
       isHidden: _intValue(['is_hidden', 'isHidden']),
       summary: _stringValue(['summary', 'digest']),
       draft: _stringValue(['draft']),
       status: _intValue(['status']),
       lastTimestamp: _intValue(['last_timestamp', 'lastTimestamp']),
       sortTimestamp: _intValue(['sort_timestamp', 'sortTimestamp']),
-      lastClearUnreadTimestamp:
-          _intValue(['last_clear_unread_timestamp', 'lastClearUnreadTimestamp']),
+      lastClearUnreadTimestamp: _intValue([
+        'last_clear_unread_timestamp',
+        'lastClearUnreadTimestamp',
+      ]),
       lastMsgLocalId: _intValue([
         'last_msg_locald_id',
         'last_msg_localid',
         'last_msg_local_id',
-        'lastMsgLocalId'
+        'lastMsgLocalId',
       ]),
       lastMsgType: _intValue(['last_msg_type', 'lastMsgType']),
       lastMsgSubType: _intValue(['last_msg_sub_type', 'lastMsgSubType']),
       lastMsgSender: _stringValue(['last_msg_sender', 'lastMsgSender']),
-      lastSenderDisplayName: _stringValue(
-        ['last_sender_display_name', 'lastSenderDisplayName'],
-      ),
+      lastSenderDisplayName: _stringValue([
+        'last_sender_display_name',
+        'lastSenderDisplayName',
+      ]),
     );
   }
 
@@ -268,6 +273,32 @@ class ChatSession {
       return '草稿: $draft';
     }
     return '';
+  }
+
+  /// 判断会话是否应该保留（过滤掉公众号、系统号等）
+  static bool shouldKeep(String username) {
+    // 排除公众号/服务号
+    if (username.startsWith('gh_')) return false;
+
+    // 排除其他系统会话
+    if (username.startsWith('weixin')) return false;
+    if (username.startsWith('qqmail')) return false;
+    if (username.startsWith('fmessage')) return false;
+    if (username.startsWith('medianote')) return false;
+    if (username.startsWith('floatbottle')) return false;
+    if (username.startsWith('newsapp')) return false;
+    // 排除客服账号
+    if (username.contains('@kefu.openim')) return false;
+    if (username.contains('@openim')) return false;
+    if (username.contains('service_')) return false;
+
+    // 统一过滤逻辑：
+    // 1. 群聊 (@chatroom)
+    // 2. 标准wxid账号 (wxid_)
+    // 3. 自定义微信号 (不含@)
+    return username.contains('@chatroom') ||
+        username.startsWith('wxid_') ||
+        !username.contains('@');
   }
 
   @override

--- a/lib/pages/chat_export_page.dart
+++ b/lib/pages/chat_export_page.dart
@@ -195,17 +195,8 @@ class _ChatExportPageState extends State<ChatExportPage> {
 
       // 过滤掉公众号/服务号
       final filteredSessions = sessions.where((session) {
-        if (session.username.startsWith('gh_')) return false;
-        if (session.username.startsWith('weixin')) return false;
-        if (session.username.startsWith('qqmail')) return false;
-        if (session.username.startsWith('fmessage')) return false;
-        if (session.username.startsWith('medianote')) return false;
-        if (session.username.startsWith('floatbottle')) return false;
-        return session.username.contains('wxid_') ||
-            session.username.contains('@chatroom');
-      }).toList();
-
-      // 保存到缓存
+        return ChatSession.shouldKeep(session.username);
+      }).toList(); // 保存到缓存
       _cachedSessions = filteredSessions;
 
       if (mounted) {

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -247,14 +247,7 @@ class _ChatPageState extends State<ChatPage> with TickerProviderStateMixin {
     try {
       final sessions = await appState.databaseService.getSessions();
       final filteredSessions = sessions.where((session) {
-        if (session.username.startsWith('gh_')) return false;
-        if (session.username.startsWith('weixin')) return false;
-        if (session.username.startsWith('qqmail')) return false;
-        if (session.username.startsWith('fmessage')) return false;
-        if (session.username.startsWith('medianote')) return false;
-        if (session.username.startsWith('floatbottle')) return false;
-        return session.username.contains('wxid_') ||
-            session.username.contains('@chatroom');
+        return ChatSession.shouldKeep(session.username);
       }).toList();
 
       if (!_sessionsChanged(filteredSessions)) return;
@@ -331,7 +324,7 @@ class _ChatPageState extends State<ChatPage> with TickerProviderStateMixin {
       if (_scrollController.hasClients) {
         final distanceToBottom =
             _scrollController.position.maxScrollExtent -
-                _scrollController.position.pixels;
+            _scrollController.position.pixels;
         if (distanceToBottom < 80) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!_scrollController.hasClients) return;
@@ -402,19 +395,8 @@ class _ChatPageState extends State<ChatPage> with TickerProviderStateMixin {
 
       // 在后台线程过滤会话
       final filteredSessions = sessions.where((session) {
-        // 排除公众号/服务号
-        if (session.username.startsWith('gh_')) return false;
-        // 排除其他系统会话
-        if (session.username.startsWith('weixin')) return false;
-        if (session.username.startsWith('qqmail')) return false;
-        if (session.username.startsWith('fmessage')) return false;
-        if (session.username.startsWith('medianote')) return false;
-        if (session.username.startsWith('floatbottle')) return false;
-        // 只保留个人聊天(wxid_)和群聊(@chatroom)
-        return session.username.contains('wxid_') ||
-            session.username.contains('@chatroom');
+        return ChatSession.shouldKeep(session.username);
       }).toList();
-
       if (mounted) {
         setState(() {
           _sessions = filteredSessions;
@@ -1079,12 +1061,13 @@ class _ChatPageState extends State<ChatPage> with TickerProviderStateMixin {
                                       );
 
                                 final avatarOwner = _isMessageFromMe(message)
-                                    ? appState.databaseService
-                                            .currentAccountWxid ??
-                                        ''
+                                    ? appState
+                                              .databaseService
+                                              .currentAccountWxid ??
+                                          ''
                                     : (message.senderUsername ??
-                                        _selectedSession?.username ??
-                                        '');
+                                          _selectedSession?.username ??
+                                          '');
                                 final animateAvatar = _shouldAnimateAvatar(
                                   avatarOwner,
                                   appState,

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -187,10 +187,7 @@ class DatabaseService {
       // 通过 WCDB DLL 打开实时加密数据库
       final handle = WeChatWCDBNative.openAccount(normalizedPath, hexKey);
       if (handle == null || handle <= 0) {
-        await logger.error(
-          'DatabaseService',
-          'WCDB DLL 打开实时数据库失败',
-        );
+        await logger.error('DatabaseService', 'WCDB DLL 打开实时数据库失败');
         // 拉取原生日志辅助定位
         final nativeLogs = WeChatWCDBNative.getNativeLogs();
         if (nativeLogs.isNotEmpty) {
@@ -245,19 +242,16 @@ class DatabaseService {
       final file = File(path);
       if (!file.existsSync()) return;
       final dir = file.parent;
-      _dbWatchSub = dir.watch(recursive: true).listen(
-        (event) {
-          final p = event.path.toLowerCase();
-          if (p.endsWith('.db') ||
-              p.endsWith('.db-wal') ||
-              p.endsWith('.db-shm') ||
-              p.contains('message_') ||
-              p.contains('session')) {
-            _dbChangeController.add(null);
-          }
-        },
-        onError: (_) => _stopRealtimeWatcher(),
-      );
+      _dbWatchSub = dir.watch(recursive: true).listen((event) {
+        final p = event.path.toLowerCase();
+        if (p.endsWith('.db') ||
+            p.endsWith('.db-wal') ||
+            p.endsWith('.db-shm') ||
+            p.contains('message_') ||
+            p.contains('session')) {
+          _dbChangeController.add(null);
+        }
+      }, onError: (_) => _stopRealtimeWatcher());
       // 初次连接也触发一次，确保 UI 能立即同步
       _dbChangeController.add(null);
     } catch (_) {
@@ -287,57 +281,51 @@ class DatabaseService {
             _wcdbGetSessions,
             _wcdbHandle!,
           );
-        await logger.info(
-          'DatabaseService',
-          '实时模式：DLL返回 ${maps.length} 条原始会话记录',
-        );
-        if (maps.isEmpty) {
-          final nativeLogs = WeChatWCDBNative.getNativeLogs();
-          if (nativeLogs.isNotEmpty) {
-            await logger.debug(
-              'DatabaseService',
-              '原生日志: ${nativeLogs.take(10).join(" | ")}',
-            );
-          }
-        }
-        if (maps.isNotEmpty) {
-          final sampleSize = maps.length > 3 ? 3 : maps.length;
-          for (var i = 0; i < sampleSize; i++) {
-            final row = maps[i];
-            await logger.debug(
-              'DatabaseService',
-              '实时模式：会话样本$i keys=${row.keys.toList()} values=${row}',
-            );
-          }
-        }
-
-        final allSessions = maps.map((map) => ChatSession.fromMap(map)).toList();
-
-        final filteredSessions = allSessions.where((session) {
-          final username = session.username;
-          final shouldKeep =
-              username.contains('@chatroom') ||
-              (username.startsWith('wxid_') && !username.contains('@')) ||
-              (!username.contains('@kefu.openim') &&
-                  !username.contains('service_') &&
-                  !username.startsWith('gh_') &&
-                  !username.contains('@openim'));
-          return shouldKeep;
-        }).toList();
-
-        // 填充显示名（从联系人数据库获取）
-        try {
-          final names = WeChatWCDBNative.getDisplayNames(
-            _wcdbHandle!,
-            filteredSessions.map((e) => e.username).toList(),
+          await logger.info(
+            'DatabaseService',
+            '实时模式：DLL返回 ${maps.length} 条原始会话记录',
           );
-          for (final s in filteredSessions) {
-            final n = names[s.username];
-            if (n != null && n.isNotEmpty) {
-              s.displayName = n;
+          if (maps.isEmpty) {
+            final nativeLogs = WeChatWCDBNative.getNativeLogs();
+            if (nativeLogs.isNotEmpty) {
+              await logger.debug(
+                'DatabaseService',
+                '原生日志: ${nativeLogs.take(10).join(" | ")}',
+              );
             }
           }
-        } catch (_) {}
+          if (maps.isNotEmpty) {
+            final sampleSize = maps.length > 3 ? 3 : maps.length;
+            for (var i = 0; i < sampleSize; i++) {
+              final row = maps[i];
+              await logger.debug(
+                'DatabaseService',
+                '实时模式：会话样本$i keys=${row.keys.toList()} values=$row',
+              );
+            }
+          }
+
+          final allSessions = maps
+              .map((map) => ChatSession.fromMap(map))
+              .toList();
+
+          final filteredSessions = allSessions.where((session) {
+            return ChatSession.shouldKeep(session.username);
+          }).toList();
+
+          // 填充显示名（从联系人数据库获取）
+          try {
+            final names = WeChatWCDBNative.getDisplayNames(
+              _wcdbHandle!,
+              filteredSessions.map((e) => e.username).toList(),
+            );
+            for (final s in filteredSessions) {
+              final n = names[s.username];
+              if (n != null && n.isNotEmpty) {
+                s.displayName = n;
+              }
+            }
+          } catch (_) {}
 
           await logger.info(
             'DatabaseService',
@@ -418,18 +406,7 @@ class DatabaseService {
 
       // 过滤掉公众号、服务号等非正常联系人
       final filteredSessions = allSessions.where((session) {
-        final username = session.username;
-
-        // 过滤条件：只显示正常联系人和群聊
-        final shouldKeep =
-            username.contains('@chatroom') ||
-            (username.startsWith('wxid_') && !username.contains('@')) ||
-            (!username.contains('@kefu.openim') &&
-                !username.contains('service_') &&
-                !username.startsWith('gh_') &&
-                !username.contains('@openim'));
-
-        return shouldKeep;
+        return ChatSession.shouldKeep(session.username);
       }).toList();
 
       await logger.info(
@@ -608,55 +585,55 @@ class DatabaseService {
     if (_mode == DatabaseMode.realtime && _wcdbHandle != null) {
       try {
         return await _withWcdbOp(() async {
-        await logger.info(
-          'DatabaseService',
-          '实时模式：通过WCDB DLL获取消息，sessionId=$sessionId, limit=$limit, offset=$offset',
-        );
-        final rows = await compute<Map<String, dynamic>,
-            List<Map<String, dynamic>>>(
-          _wcdbGetMessages,
-          {
-            'handle': _wcdbHandle!,
-            'username': sessionId,
-            'limit': limit,
-            'offset': offset,
-          },
-        );
-        if (rows.isEmpty) {
-          final nativeLogs = WeChatWCDBNative.getNativeLogs();
-          if (nativeLogs.isNotEmpty) {
-            await logger.debug(
-              'DatabaseService',
-              '原生日志(消息查询): ${nativeLogs.take(10).join(" | ")}',
-            );
-          }
-        } else {
-          final sampleSize = rows.length > 3 ? 3 : rows.length;
-          for (int i = 0; i < sampleSize; i++) {
-            await logger.debug(
-              'DatabaseService',
-              '消息样本$i keys=${rows[i].keys.toList()} raw_time=${rows[i]['create_time'] ?? rows[i]['sort_seq']} sort_seq=${rows[i]['sort_seq']} local_id=${rows[i]['local_id']} server_id=${rows[i]['server_id']}',
-            );
-          }
-        }
-        final messages = rows
-            .map(
-              (map) =>
-                  Message.fromMap(map, myWxid: _currentAccountWxid ?? ''),
-            )
-            .toList();
-        await logger.info(
-          'DatabaseService',
-          '实时模式：消息映射完成 rows=${rows.length} messages=${messages.length}',
-        );
-        if (messages.isNotEmpty) {
-          final first = messages.first;
-          final last = messages.length > 1 ? messages.last : messages.first;
-          await logger.debug(
+          await logger.info(
             'DatabaseService',
-            '消息映射时间范围: first=${first.createTime} sortSeq=${first.sortSeq} serverSeq=${first.serverSeq} | last=${last.createTime} sortSeq=${last.sortSeq} serverSeq=${last.serverSeq}',
+            '实时模式：通过WCDB DLL获取消息，sessionId=$sessionId, limit=$limit, offset=$offset',
           );
-        }
+          final rows =
+              await compute<Map<String, dynamic>, List<Map<String, dynamic>>>(
+                _wcdbGetMessages,
+                {
+                  'handle': _wcdbHandle!,
+                  'username': sessionId,
+                  'limit': limit,
+                  'offset': offset,
+                },
+              );
+          if (rows.isEmpty) {
+            final nativeLogs = WeChatWCDBNative.getNativeLogs();
+            if (nativeLogs.isNotEmpty) {
+              await logger.debug(
+                'DatabaseService',
+                '原生日志(消息查询): ${nativeLogs.take(10).join(" | ")}',
+              );
+            }
+          } else {
+            final sampleSize = rows.length > 3 ? 3 : rows.length;
+            for (int i = 0; i < sampleSize; i++) {
+              await logger.debug(
+                'DatabaseService',
+                '消息样本$i keys=${rows[i].keys.toList()} raw_time=${rows[i]['create_time'] ?? rows[i]['sort_seq']} sort_seq=${rows[i]['sort_seq']} local_id=${rows[i]['local_id']} server_id=${rows[i]['server_id']}',
+              );
+            }
+          }
+          final messages = rows
+              .map(
+                (map) =>
+                    Message.fromMap(map, myWxid: _currentAccountWxid ?? ''),
+              )
+              .toList();
+          await logger.info(
+            'DatabaseService',
+            '实时模式：消息映射完成 rows=${rows.length} messages=${messages.length}',
+          );
+          if (messages.isNotEmpty) {
+            final first = messages.first;
+            final last = messages.length > 1 ? messages.last : messages.first;
+            await logger.debug(
+              'DatabaseService',
+              '消息映射时间范围: first=${first.createTime} sortSeq=${first.sortSeq} serverSeq=${first.serverSeq} | last=${last.createTime} sortSeq=${last.sortSeq} serverSeq=${last.serverSeq}',
+            );
+          }
           return messages;
         });
       } catch (e, stackTrace) {
@@ -2533,10 +2510,7 @@ class DatabaseService {
 
     // 如果有实时调用在运行，等待它们结束，避免关闭句柄时崩溃
     if (_mode == DatabaseMode.realtime && _activeWcdbOps > 0) {
-      await logger.info(
-        'DatabaseService',
-        '等待 ${_activeWcdbOps} 个实时调用完成后再关闭...',
-      );
+      await logger.info('DatabaseService', '等待 $_activeWcdbOps 个实时调用完成后再关闭...');
       int waitedMs = 0;
       while (_activeWcdbOps > 0) {
         await Future.delayed(const Duration(milliseconds: 100));
@@ -2548,10 +2522,7 @@ class DatabaseService {
           );
         }
       }
-      await logger.info(
-        'DatabaseService',
-        '实时调用已全部结束，继续关闭',
-      );
+      await logger.info('DatabaseService', '实时调用已全部结束，继续关闭');
     }
 
     // 实时模式：关闭 WCDB 账号句柄
@@ -3380,6 +3351,16 @@ class DatabaseService {
           'DatabaseService',
           '成功加载联系人信息，已更新${sessions.where((s) => s.displayName != null && s.displayName!.isNotEmpty).length}个会话的显示名称',
         );
+        // 打印没有成功更新显示名称的会话
+        // final sessionsWithoutDisplayName = sessions
+        //     .where((s) => s.displayName == null || s.displayName!.isEmpty)
+        //     .toList();
+        // if (sessionsWithoutDisplayName.isNotEmpty) {
+        //   await logger.warning('DatabaseService', '以下会话未能更新显示名称:');
+        //   for (final session in sessionsWithoutDisplayName) {
+        //     await logger.warning('DatabaseService', '  - ${session.username}');
+        //   }
+        // }
       } finally {
         await contactDb.close();
       }
@@ -4957,7 +4938,7 @@ class DatabaseService {
       final startTime = startDate.millisecondsSinceEpoch ~/ 1000;
       final endTime = endOfDay.millisecondsSinceEpoch ~/ 1000;
       final messages = await getMessagesByDate(chatroomId, startTime, endTime);
-      
+
       for (final message in messages) {
         // 从秒级时间戳创建 DateTime 对象
         final messageTime = DateTime.fromMillisecondsSinceEpoch(
@@ -4970,8 +4951,7 @@ class DatabaseService {
       }
 
       // --- 打印最终结果 ---
-    } catch (e) {
-    }
+    } catch (e) {}
 
     return hourlyCounts;
   }
@@ -5053,8 +5033,7 @@ class DatabaseService {
           }
         } catch (e) {}
       }
-    } catch (e) {
-    }
+    } catch (e) {}
 
     return typeCounts;
   }


### PR DESCRIPTION
## 变更概述

本次PR包含两个关键修复，旨在解决聊天记录显示不全和联系人过滤逻辑不一致的问题。

### 主要变更

#### 1. 修复聊天记录显示不全问题 (提交 09508e7)
- **问题描述**：在聊天记录 → 会话列表 → 聊天详情的流程中，部分消息记录未能完全显示。
- **根本原因**：数据库文件查找范围限制为 `message_0.db` 到 `message_9.db`，当数据库分片超过10个时，会遗漏部分数据。
- **解决方案**：
  - 将查找范围扩展到 `message_0.db` 到 `message_99.db`（共100个文件）。
  - 添加日志记录，便于调试和监控数据库查找过程。
- **影响**：确保所有分片的数据库文件都能被正确加载，提升数据完整性。

#### 2. 统一联系人过滤条件 (提交 3fba67d)
- **问题描述**：自定义账号（如 `qwe964294`）的联系人无法在会话列表中显示。
- **根本原因**：过滤逻辑不一致
- **解决方案**：
  - 在 `ChatSession` 模型中添加统一的 `shouldKeep` 静态方法，集中处理过滤逻辑。
  - 排除系统账号（如 `gh_` 开头的公众号），但保留自定义用户名。
  - 更新所有相关文件（`chat_page.dart`、`chat_export_page.dart`、`database_service.dart`）使用统一方法。
  - 添加调试日志，输出会话用户名和过滤结果。
- **影响**：确保所有有效联系人（包括自定义账号）都能正确显示在会话列表中。

### 相关文件
- database_service.dart：数据库文件查找和过滤逻辑
- chat_session.dart：新增统一过滤方法
- chat_page.dart：会话加载逻辑更新
- chat_export_page.dart：导出过滤逻辑更新