### PR TITLE
fix: remove hardcoded limit in getSessions() to load all sessions

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -297,7 +297,8 @@ class DatabaseService {
   Database? get _currentDb => _sessionDb;
 
   /// 获取会话列表
-  Future<List<ChatSession>> getSessions({int limit = 400}) async {
+  /// [limit] 为 null 时不限制数量，默认不限制以支持完整导出
+  Future<List<ChatSession>> getSessions({int? limit}) async {
     // 实时模式：通过 WCDB DLL 获取会话
     if (_mode == DatabaseMode.realtime && _wcdbHandle != null) {
       try {
@@ -413,12 +414,12 @@ class DatabaseService {
         }
       }
 
-      await logger.info('DatabaseService', '从表 $sessionTableName 查询会话');
+      await logger.info('DatabaseService', '从表 $sessionTableName 查询会话${limit != null ? '（限制 $limit 条）' : '（无限制）'}');
 
       final List<Map<String, dynamic>> maps = await db.query(
         sessionTableName,
         orderBy: 'sort_timestamp DESC',
-        limit: limit,
+        limit: limit,  // null 表示不限制
       );
 
       await logger.info('DatabaseService', '查询到 ${maps.length} 条原始会话记录');


### PR DESCRIPTION
## 问题描述
修复 #94 

用户有 7000+ 联系人和会话，但 UI 界面会话列表只显示 373 个，无法导出全部数据。

## 根本原因
`DatabaseService.getSessions()` 方法有一个硬编码的默认限制 `limit = 400`，导致：
- UI 最多只能显示约 400 条会话（过滤后约 373 条）
- CLI 导出只能导出这 400 条会话
- 导出功能无法导出完整数据

## 解决方案
将 `limit` 参数从 `int limit = 400` 改为 `int? limit`（默认 `null` 表示不限制）。

## 修改内容
- `lib/services/database_service.dart`: 修改 `getSessions()` 方法签名

## 兼容性
此修改向后兼容，所有现有调用 `getSessions()` 的代码无需修改。