### PR TITLE
fix: 尝试优化了一下年度报告中-曾经的好朋友的判断逻辑

### DIFF
--- a/lib/cli/cli_export_runner.dart
+++ b/lib/cli/cli_export_runner.dart
@@ -389,13 +389,15 @@ class CliExportRunner {
       _cancelled = true;
       _logError('收到 Ctrl+C/SIGINT，准备中止...');
     });
-    try {
-      _sigTermSub = ProcessSignal.sigterm.watch().listen((_) {
-        _cancelled = true;
-        _logError('收到 SIGTERM，准备中止...');
-      });
-    } catch (_) {
-      // Windows 可能不支持 SIGTERM，忽略
+    if (!Platform.isWindows) {
+      try {
+        _sigTermSub = ProcessSignal.sigterm.watch().listen((_) {
+          _cancelled = true;
+          _logError('收到 SIGTERM，准备中止...');
+        });
+      } catch (_) {
+        // SIGTERM 可能不支持，忽略
+      }
     }
   }
 


### PR DESCRIPTION
## 问题
  原逻辑在遍历会话时就进行筛选，可能会错过更合适的候选人。此外，缺少离别天数的判断，导致只离别1天的联系人也被判定为"曾经的好朋友"。

  ## 改进
  1. **第一阶段**：收集所有连续聊天 >= 14天的候选人（不进行其他过滤）
  2. **第二阶段**：按连续聊天天数从高到低排序
  3. **第三阶段**：筛选符合条件的好友
     近期频率 <= 5条/天
     **离别天数 >= 7天**（新增判断）
修改前：
<img width="1617" height="939" alt="微信图片_20251227141627_558_236" src="https://github.com/user-attachments/assets/bad1a3a9-0607-40c3-aac5-777d5586de4c" />
修改后：
<img width="1533" height="954" alt="ScreenShot_2025-12-27_151135_008" src="https://github.com/user-attachments/assets/c376f087-440b-4b5e-8574-32f31c68aa39" />
