### PR TITLE
fix: 清理lint警告并修复年度报告错别字

### DIFF
--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -1975,8 +1975,7 @@ class _ChatPageState extends State<ChatPage> with TickerProviderStateMixin {
             );
 
             await Future.any([
-              // ignore: body_might_complete_normally_catch_error
-              decodeFuture.catchError((_) {}),
+              decodeFuture.catchError((_) => null),
               waitReady,
             ]).timeout(const Duration(seconds: 60));
 

--- a/lib/pages/data_management_page.dart
+++ b/lib/pages/data_management_page.dart
@@ -3241,7 +3241,6 @@ class _SmoothLinearProgress extends StatefulWidget {
     required this.backgroundColor,
     required this.valueColor,
     this.duration = const Duration(milliseconds: 420),
-    // ignore: unused_element_parameter
     this.curve = Curves.easeOutCubic,
   });
 

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unused_field
-
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
@@ -41,9 +39,6 @@ class _SettingsPageState extends State<SettingsPage>
   final _wxidScanService = WxidScanService();
   late final ToastOverlay _toast;
 
-  final bool _obscureKey = true;
-  final bool _obscureImageXorKey = true;
-  final bool _obscureImageAesKey = true;
   bool _isLoading = false;
   String? _statusMessage;
   bool _isSuccess = false;
@@ -834,7 +829,7 @@ class _SettingsPageState extends State<SettingsPage>
               subtitle: '请输入64位十六进制密钥',
               child: TextFormField(
                 controller: _keyController,
-                obscureText: _obscureKey,
+                obscureText: true,
                 decoration: InputDecoration(
                   hintText: '例如: a1b2c3d4e5f6...',
                   border: OutlineInputBorder(
@@ -1199,7 +1194,7 @@ class _SettingsPageState extends State<SettingsPage>
               subtitle: '2位十六进制密钥（支持0x前缀），例如：0x53 或 53',
               child: TextFormField(
                 controller: _imageXorKeyController,
-                obscureText: _obscureImageXorKey,
+                obscureText: true,
                 decoration: InputDecoration(
                   hintText: '例如: 0x12 或 A3',
                   border: OutlineInputBorder(
@@ -1251,7 +1246,7 @@ class _SettingsPageState extends State<SettingsPage>
               subtitle: '至少16个字符的字母数字字符串，从微信进程内存获取',
               child: TextFormField(
                 controller: _imageAesKeyController,
-                obscureText: _obscureImageAesKey,
+                obscureText: true,
                 decoration: InputDecoration(
                   hintText: '例如: b123456789012345...',
                   border: OutlineInputBorder(

--- a/lib/services/analytics_background_service.dart
+++ b/lib/services/analytics_background_service.dart
@@ -47,7 +47,6 @@ class _AnalyticsTask {
   final List<String> excludedUsernames;
   final SendPort sendPort;
   final RootIsolateToken rootIsolateToken;
-  final String? myWxid; // 当前用户的 wxid（用于词云等只统计自己消息的场景）
 
   _AnalyticsTask({
     required this.dbPath,
@@ -57,7 +56,6 @@ class _AnalyticsTask {
     required this.excludedUsernames,
     required this.sendPort,
     required this.rootIsolateToken,
-    this.myWxid,
   });
 }
 
@@ -86,10 +84,9 @@ typedef AnalyticsProgressCallback =
 /// 所有分析任务都在后台运行，只返回最终结果
 class AnalyticsBackgroundService {
   final String dbPath;
-  final String? myWxid; // 当前用户的 wxid
   Set<String> _excludedUsernames = {};
 
-  AnalyticsBackgroundService(this.dbPath, {this.myWxid, Set<String>? excludedUsernames}) {
+  AnalyticsBackgroundService(this.dbPath, {Set<String>? excludedUsernames}) {
     if (excludedUsernames != null) {
       _excludedUsernames =
           excludedUsernames.map((name) => name.toLowerCase()).toSet();
@@ -259,7 +256,6 @@ class AnalyticsBackgroundService {
         excludedUsernames: _excludedUsernames.toList(),
         sendPort: receivePort.sendPort,
         rootIsolateToken: ServicesBinding.rootIsolateToken!,
-        myWxid: myWxid,
       );
 
       await logger.debug('RunAnalysis', '准备启动Isolate: $analysisType');
@@ -1000,193 +996,6 @@ class AnalyticsBackgroundService {
               };
               break;
 
-            case 'word_cloud':
-              final yearText = task.filterYear != null ? '${task.filterYear}年' : '全部';
-              sendLog('开始生成词云数据（年份：$yearText）', level: 'info');
-              task.sendPort.send(
-                _AnalyticsMessage(
-                  type: 'progress',
-                  stage: '正在分析文本消息...',
-                  current: 30,
-                  total: 100,
-                  elapsedSeconds: DateTime.now()
-                      .difference(startTime)
-                      .inSeconds,
-                  estimatedRemainingSeconds: _estimateRemainingTime(
-                    30,
-                    100,
-                    startTime,
-                  ),
-                ),
-              );
-
-              // 获取文本消息（只获取当前用户发送的消息，不限制数量）
-              // 如果指定了年份，必须获取该年份的所有消息
-              sendLog('开始查询${yearText}的所有聊天记录...', level: 'info');
-              var lastProgress = 30;
-              final messages = await dbService.getTextMessagesForWordCloud(
-                year: task.filterYear,
-                excludedUsernames: task.excludedUsernames.toSet(),
-                onlyMySent: true,
-                myWxid: task.myWxid,
-                onLog: (message, {String level = 'info'}) {
-                  sendLog(message, level: level);
-                },
-                onProgress: (current, total, stage) {
-                  if (total <= 0) return;
-                  final progress = 30 + ((current / total) * 15).floor();
-                  if (progress == lastProgress) return;
-                  lastProgress = progress;
-                  task.sendPort.send(
-                    _AnalyticsMessage(
-                      type: 'progress',
-                      stage: stage,
-                      current: progress,
-                      total: 100,
-                      elapsedSeconds: DateTime.now()
-                          .difference(startTime)
-                          .inSeconds,
-                      estimatedRemainingSeconds: _estimateRemainingTime(
-                        progress,
-                        100,
-                        startTime,
-                      ),
-                    ),
-                  );
-                },
-              );
-              sendLog('${yearText}共获取到 ${messages.length} 条我发送的文本消息', level: 'info');
-
-              task.sendPort.send(
-                _AnalyticsMessage(
-                  type: 'progress',
-                  stage: '正在统计句子频率...',
-                  current: 50,
-                  total: 100,
-                  elapsedSeconds: DateTime.now()
-                      .difference(startTime)
-                      .inSeconds,
-                  estimatedRemainingSeconds: _estimateRemainingTime(
-                    50,
-                    100,
-                    startTime,
-                  ),
-                ),
-              );
-
-              // 统计完整句子的出现频率
-              final sentenceCount = <String, int>{};
-              
-              // 清理和规范化句子
-              String normalizeSentence(String text) {
-                // 去除首尾空白
-                text = text.trim();
-                // 将多个连续空白/换行符替换为单个空格
-                text = text.replaceAll(RegExp(r'\s+'), ' ');
-                // 去除常见的消息标记
-                text = text.replaceAll(RegExp(r'^\[.*?\]'), ''); // 去除 [xxx] 开头
-                text = text.trim();
-                return text;
-              }
-              
-              // 判断句子是否有效（放宽条件，确保更多句子被统计）
-              bool isValidSentence(String sentence) {
-                if (sentence.isEmpty) return false;
-                // 长度限制：至少2个字符，最多500个字符（放宽上限）
-                if (sentence.length < 2 || sentence.length > 500) return false;
-                
-                // 跳过包含 wxid 的句子（通常是引用消息）
-                if (sentence.contains('wxid_') || 
-                    sentence.contains('wxid:') ||
-                    sentence.toLowerCase().contains('wxid')) {
-                  return false;
-                }
-                
-                // 跳过纯数字（但允许包含数字的句子）
-                if (RegExp(r'^\d+$').hasMatch(sentence)) return false;
-                
-                // 放宽条件：中文字符、英文字母、数字的总数应该至少占20%（从30%降低）
-                final chineseChars = RegExp(r'[\u4e00-\u9fa5]').allMatches(sentence).length;
-                final englishChars = RegExp(r'[a-zA-Z]').allMatches(sentence).length;
-                final digits = RegExp(r'\d').allMatches(sentence).length;
-                final meaningfulChars = chineseChars + englishChars + digits;
-                // 如果句子很短（<=5个字符），只要有1个有意义字符即可
-                if (sentence.length <= 5) {
-                  if (meaningfulChars == 0) return false;
-                } else {
-                  // 长句子要求至少20%是有意义字符
-                  if (meaningfulChars / sentence.length < 0.2) return false;
-                }
-                
-                // 跳过只有单个字符重复的句子（如 "哈哈哈"、"..."），但允许2-3个字符的重复
-                if (sentence.length > 5) {
-                  final firstChar = sentence[0];
-                  if (sentence.split('').every((c) => c == firstChar)) {
-                    return false;
-                  }
-                }
-                
-                // 只跳过最常见的无意义单字符回复
-                final meaninglessSingleChars = {
-                  '嗯', '哦', '啊', '额', '呃',
-                };
-                if (sentence.length == 1 && meaninglessSingleChars.contains(sentence)) {
-                  return false;
-                }
-                
-                return true;
-              }
-
-              for (final content in messages) {
-                if (content.isEmpty) continue;
-                
-                // 规范化句子
-                final normalized = normalizeSentence(content);
-                
-                // 检查句子是否有效
-                if (!isValidSentence(normalized)) continue;
-                
-                // 统计句子频率
-                sentenceCount[normalized] = (sentenceCount[normalized] ?? 0) + 1;
-              }
-
-              task.sendPort.send(
-                _AnalyticsMessage(
-                  type: 'progress',
-                  stage: '正在整理句子数据...',
-                  current: 80,
-                  total: 100,
-                  elapsedSeconds: DateTime.now()
-                      .difference(startTime)
-                      .inSeconds,
-                  estimatedRemainingSeconds: _estimateRemainingTime(
-                    80,
-                    100,
-                    startTime,
-                  ),
-                ),
-              );
-
-              // 过滤并排序，取前100个高频句子
-              final sortedSentences = sentenceCount.entries.toList()
-                ..sort((a, b) => b.value.compareTo(a.value));
-              
-              sendLog('句子统计：共找到 ${sentenceCount.length} 个不同的句子，总出现次数 ${sortedSentences.fold(0, (sum, e) => sum + e.value)}', level: 'info');
-              
-              final topSentences = sortedSentences
-                  .where((e) => e.value >= 1) // 至少出现1次（显示所有句子）
-                  .take(100)
-                  .map((e) => {'word': e.key, 'count': e.value})
-                  .toList();
-
-              sendLog('句子统计完成，共 ${topSentences.length} 个高频句子（前100个）', level: 'info');
-              result = {
-                'words': topSentences,
-                'totalWords': sentenceCount.length,
-                'totalMessages': messages.length,
-              };
-              break;
-
             default:
               sendLog('未知的分析类型: ${task.analysisType}', level: 'error');
               throw Exception('未知的分析类型: ${task.analysisType}');
@@ -1439,19 +1248,6 @@ class AnalyticsBackgroundService {
     };
   }
 
-  /// 词云分析（后台版本）
-  Future<Map<String, dynamic>> analyzeWordCloudInBackground(
-    int? filterYear,
-    AnalyticsProgressCallback progressCallback,
-  ) async {
-    final result = await _runAnalysisInIsolate(
-      analysisType: 'word_cloud',
-      filterYear: filterYear,
-      progressCallback: progressCallback,
-    );
-    return result as Map<String, dynamic>;
-  }
-
   /// 生成完整年度报告（并行执行所有任务）
   Future<Map<String, dynamic>> generateFullAnnualReport(
     int? filterYear,
@@ -1483,7 +1279,6 @@ class AnalyticsBackgroundService {
       '深夜密友',
       '最快响应好友',
       '我回复最快',
-      '年度词云',
       if (includeFormerFriends) '曾经的好朋友',
     ];
 
@@ -1523,7 +1318,7 @@ class AnalyticsBackgroundService {
     final timeout = const Duration(minutes: 5);
     await logger.debug('AnnualReport', '任务超时设置: ${timeout.inMinutes} 分钟');
 
-    await logger.info('AnnualReport', '开始任务 1/14: 绝对核心好友');
+    await logger.info('AnnualReport', '开始任务 1/13: 绝对核心好友');
     final coreFriendsData =
         await getAbsoluteCoreFriendsInBackground(
           filterYear,
@@ -1535,9 +1330,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析绝对核心好友超时，数据量可能过大');
           },
         );
-    await logger.info('AnnualReport', '完成任务 1/14: 绝对核心好友');
+    await logger.info('AnnualReport', '完成任务 1/13: 绝对核心好友');
 
-    await logger.info('AnnualReport', '开始任务 2/14: 年度倾诉对象');
+    await logger.info('AnnualReport', '开始任务 2/13: 年度倾诉对象');
     final confidant =
         await getConfidantObjectsInBackground(
           filterYear,
@@ -1549,9 +1344,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析年度倾诉对象超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 2/14: 年度倾诉对象');
+    await logger.info('AnnualReport', '完成任务 2/13: 年度倾诉对象');
 
-    await logger.info('AnnualReport', '开始任务 3/14: 年度最佳听众');
+    await logger.info('AnnualReport', '开始任务 3/13: 年度最佳听众');
     final listeners =
         await getBestListenersInBackground(
           filterYear,
@@ -1563,9 +1358,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析年度最佳听众超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 3/14: 年度最佳听众');
+    await logger.info('AnnualReport', '完成任务 3/13: 年度最佳听众');
 
-    await logger.info('AnnualReport', '开始任务 4/14: 月度好友');
+    await logger.info('AnnualReport', '开始任务 4/13: 月度好友');
     final monthlyTopFriendsData =
         await getMonthlyTopFriendsInBackground(
           filterYear,
@@ -1577,9 +1372,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析月度好友超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 4/14: 月度好友');
+    await logger.info('AnnualReport', '完成任务 4/13: 月度好友');
 
-    await logger.info('AnnualReport', '开始任务 5/14: 双向奔赴好友');
+    await logger.info('AnnualReport', '开始任务 5/13: 双向奔赴好友');
     final mutualFriends =
         await getMutualFriendsRankingInBackground(
           filterYear,
@@ -1591,9 +1386,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析双向奔赴好友超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 5/14: 双向奔赴好友');
+    await logger.info('AnnualReport', '完成任务 5/13: 双向奔赴好友');
 
-    await logger.info('AnnualReport', '开始任务 6/14: 主动社交指数');
+    await logger.info('AnnualReport', '开始任务 6/13: 主动社交指数');
     final socialInitiative =
         await analyzeSocialInitiativeRateInBackground(
           filterYear,
@@ -1605,9 +1400,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析主动社交指数超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 6/14: 主动社交指数');
+    await logger.info('AnnualReport', '完成任务 6/13: 主动社交指数');
 
-    await logger.info('AnnualReport', '开始任务 7/14: 聊天巅峰日');
+    await logger.info('AnnualReport', '开始任务 7/13: 聊天巅峰日');
     final peakDay =
         await analyzePeakChatDayInBackground(
           filterYear,
@@ -1619,9 +1414,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析聊天巅峰日超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 7/14: 聊天巅峰日');
+    await logger.info('AnnualReport', '完成任务 7/13: 聊天巅峰日');
 
-    await logger.info('AnnualReport', '开始任务 8/14: 连续打卡记录');
+    await logger.info('AnnualReport', '开始任务 8/13: 连续打卡记录');
     final checkIn =
         await findLongestCheckInRecordInBackground(
           filterYear,
@@ -1633,9 +1428,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析连续打卡记录超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 8/14: 连续打卡记录');
+    await logger.info('AnnualReport', '完成任务 8/13: 连续打卡记录');
 
-    await logger.info('AnnualReport', '开始任务 9/14: 作息图谱');
+    await logger.info('AnnualReport', '开始任务 9/13: 作息图谱');
     final activityPattern =
         await analyzeActivityPatternInBackground(
           filterYear,
@@ -1647,9 +1442,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析作息图谱超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 9/14: 作息图谱');
+    await logger.info('AnnualReport', '完成任务 9/13: 作息图谱');
 
-    await logger.info('AnnualReport', '开始任务 10/14: 深夜密友');
+    await logger.info('AnnualReport', '开始任务 10/13: 深夜密友');
     final midnightKing =
         await findMidnightChatKingInBackground(
           filterYear,
@@ -1661,9 +1456,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析深夜密友超时');
           },
         );
-    await logger.info('AnnualReport', '完成任务 10/14: 深夜密友');
+    await logger.info('AnnualReport', '完成任务 10/13: 深夜密友');
 
-    await logger.info('AnnualReport', '开始任务 11/14: 最快响应好友');
+    await logger.info('AnnualReport', '开始任务 11/13: 最快响应好友');
     final whoRepliesFastest =
         await analyzeWhoRepliesFastestInBackground(
           filterYear,
@@ -1675,9 +1470,9 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析最快响应好友超时，可能因为好友数量过多');
           },
         );
-    await logger.info('AnnualReport', '完成任务 11/14: 最快响应好友');
+    await logger.info('AnnualReport', '完成任务 11/13: 最快响应好友');
 
-    await logger.info('AnnualReport', '开始任务 12/14: 我回复最快');
+    await logger.info('AnnualReport', '开始任务 12/13: 我回复最快');
     final myFastestReplies =
         await analyzeMyFastestRepliesInBackground(
           filterYear,
@@ -1689,31 +1484,13 @@ class AnalyticsBackgroundService {
             throw TimeoutException('分析我回复最快超时，可能因为好友数量过多');
           },
         );
-    await logger.info('AnnualReport', '完成任务 12/14: 我回复最快');
-
-    await logger.info('AnnualReport', '开始任务 13/14: 年度词云');
-    Map<String, dynamic> wordCloudData = {'words': [], 'totalWords': 0, 'totalMessages': 0};
-    try {
-      wordCloudData = await analyzeWordCloudInBackground(
-        filterYear,
-        createProgressCallback('年度词云'),
-      ).timeout(
-        timeout,
-        onTimeout: () {
-          logger.error('AnnualReport', '任务超时: 年度词云');
-          throw TimeoutException('分析年度词云超时');
-        },
-      );
-    } catch (e) {
-      await logger.warning('AnnualReport', '词云分析失败，使用空数据: $e');
-    }
-    await logger.info('AnnualReport', '完成任务 13/14: 年度词云');
+    await logger.info('AnnualReport', '完成任务 12/13: 我回复最快');
 
     List<Map<String, dynamic>> formerFriends = [];
     Map<String, dynamic>? formerFriendsStats;
 
     if (includeFormerFriends) {
-      await logger.info('AnnualReport', '开始任务 14/14: 曾经的好朋友');
+      await logger.info('AnnualReport', '开始任务 13/13: 曾经的好朋友');
       final formerFriendsData =
           await analyzeFormerFriendsInBackground(
             filterYear,
@@ -1725,7 +1502,7 @@ class AnalyticsBackgroundService {
               throw TimeoutException('分析曾经的好朋友超时');
             },
           );
-      await logger.info('AnnualReport', '完成任务 14/14: 曾经的好朋友');
+      await logger.info('AnnualReport', '完成任务 13/13: 曾经的好朋友');
 
       formerFriends =
           formerFriendsData['results'] as List<Map<String, dynamic>>;
@@ -1799,7 +1576,6 @@ class AnalyticsBackgroundService {
       'midnightKing': midnightKing,
       'whoRepliesFastest': whoRepliesFastest,
       'myFastestReplies': myFastestReplies,
-      'wordCloud': wordCloudData,
       'formerFriends': formerFriends,
       'formerFriendsStats': formerFriendsStats,
     };

--- a/lib/services/chat_export_service.dart
+++ b/lib/services/chat_export_service.dart
@@ -418,8 +418,7 @@ class _MediaExportHelper {
       try {
         final decodeFuture = voiceService
             .ensureVoiceDecoded(message, _options.sessionUsername)
-            // ignore: body_might_complete_normally_catch_error
-            .catchError((_) {});
+            .catchError((_) => null);
         await Future.any([
           decodeFuture,
           _waitForFileReady(outputFile, const Duration(seconds: 90)),

--- a/lib/services/word_cloud_service.dart
+++ b/lib/services/word_cloud_service.dart
@@ -1,0 +1,311 @@
+// 文件: lib/services/word_cloud_service.dart
+// 统一的词云/常用语分析服务
+
+/// 分析模式
+enum WordCloudMode {
+  /// 句子模式：统计完整句子的出现频率（适用于年度常用语、双人报告）
+  sentence,
+
+  /// 词语模式：使用二元分词统计词频（适用于群聊词云）
+  word,
+}
+
+/// 分析结果
+class WordCloudResult {
+  /// 词频列表，每项包含 word 和 count
+  final List<Map<String, dynamic>> words;
+
+  /// 不同词/句子的总数
+  final int totalUniqueCount;
+
+  /// 处理的消息总数
+  final int totalMessages;
+
+  WordCloudResult({
+    required this.words,
+    required this.totalUniqueCount,
+    required this.totalMessages,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'words': words,
+        'totalWords': totalUniqueCount,
+        'totalMessages': totalMessages,
+      };
+
+  bool get isEmpty => words.isEmpty;
+}
+
+/// 统一的词云/常用语分析服务
+class WordCloudService {
+  static WordCloudService? _instance;
+  static WordCloudService get instance => _instance ??= WordCloudService._();
+
+  WordCloudService._();
+
+  /// 中文停用词表（扩充版，约200个常用停用词）
+  static final Set<String> chineseStopwords = {
+    // === 代词 ===
+    '我', '你', '他', '她', '它', '们', '我们', '你们', '他们', '她们', '它们',
+    '自己', '人家', '咱', '咱们', '大家', '别人', '谁', '某', '某人', '某些',
+    '这', '那', '这个', '那个', '这些', '那些', '这里', '那里', '这儿', '那儿',
+    '什么', '怎么', '哪', '哪个', '哪些', '哪里', '哪儿', '多少', '几', '几个',
+
+    // === 助词 ===
+    '的', '地', '得', '了', '着', '过', '吗', '呢', '吧', '啊', '呀', '啦',
+    '哦', '嗯', '哈', '嘿', '哼', '哎', '唉', '额', '呃', '嘛', '噢', '喔',
+    '呵', '嘻', '嗨', '哟', '诶', '欸', '咦', '呐', '嘞', '咯', '哩', '嘎',
+
+    // === 连词介词 ===
+    '和', '与', '或', '但', '但是', '而', '而且', '并', '并且', '不但', '不仅',
+    '因为', '所以', '因此', '如果', '假如', '要是', '虽然', '虽', '即使', '尽管',
+    '然后', '接着', '于是', '既然', '无论', '不论', '不管', '只要', '只有', '除非',
+    '就', '就是', '也', '都', '还', '又', '再', '才', '便', '却', '倒', '反而',
+    '在', '从', '到', '对', '向', '把', '被', '给', '跟', '比', '按', '照', '为',
+    '以', '用', '让', '拿', '替', '经', '由', '将', '当', '作为', '关于', '至于',
+
+    // === 副词 ===
+    '很', '非常', '太', '更', '最', '挺', '真', '好', '特别', '相当', '十分', '极',
+    '不', '没', '没有', '别', '未', '无', '莫', '勿', '休',
+    '是', '有', '会', '能', '可以', '可能', '应该', '必须', '需要', '要', '想', '去',
+    '来', '做', '干', '搞', '弄', '整', '办', '行', '算', '成',
+    '已', '已经', '正在', '正', '刚', '刚才', '曾', '曾经', '将要', '快', '快要',
+    '大概', '或许', '一定', '肯定', '当然', '果然', '确实', '的确', '究竟', '到底',
+
+    // === 量词 ===
+    '个', '些', '点', '下', '次', '回', '遍', '趟', '番', '场', '阵',
+    '只', '条', '张', '件', '本', '支', '块', '片', '根', '棵', '颗',
+
+    // === 时间词 ===
+    '时候', '之后', '之前', '以后', '以前', '后来', '当时', '那时', '这时',
+    '现在', '目前', '今天', '明天', '昨天', '前天', '后天', '今年', '明年', '去年',
+    '早上', '上午', '中午', '下午', '晚上', '半夜', '凌晨',
+
+    // === 方位词 ===
+    '上', '下', '左', '右', '前', '后', '里', '外', '中', '内', '间', '旁', '边',
+    '上面', '下面', '前面', '后面', '里面', '外面', '中间', '旁边', '这边', '那边',
+
+    // === 其他常见无意义词 ===
+    '一', '一个', '一些', '一样', '一下', '一点', '一起', '一直', '一边',
+    '这样', '那样', '这么', '那么', '怎样', '如何', '怎么样', '什么样',
+    '还是', '或者', '不是', '知道', '觉得', '感觉', '认为', '发现', '看到', '听到',
+    '的话', '东西', '事情', '问题', '情况', '方面', '地方', '样子', '意思',
+    '起来', '过来', '过去', '出来', '进来', '回来', '上来', '下来', '出去', '进去',
+    '说', '讲', '问', '答', '看', '听', '写', '读', '说道', '告诉',
+
+    // === 网络用语/脏话（过滤）===
+    '卧槽', '我靠', '淦', '艹', '尼玛', '妈的', '草', '靠', '操', '日',
+    '傻逼', '牛逼', '装逼', '逼', '屌', '滚', '妈', '爹', '爸',
+  };
+
+  /// 表情类重复词（保留，不过滤）
+  static final Set<String> _emotionalRepeatPatterns = {
+    '哈', '呵', '嘿', '嘻', '呜', '唉', '哎', '嗯', '噢', '哦',
+    '啊', '呀', '耶', '哟', '喂', '嘞', '咯', '嘎', '嗷', '喵',
+  };
+
+  /// 分析文本生成词云/常用语数据
+  ///
+  /// [texts] 待分析的文本列表
+  /// [mode] 分析模式：句子模式或词语模式
+  /// [topN] 返回前N个高频项
+  /// [minCount] 最小出现次数
+  /// [minLength] 最小长度（词语模式下为词长，句子模式下为句子长度）
+  /// [maxLength] 最大长度（句子模式下有效）
+  Future<WordCloudResult> analyze({
+    required List<String> texts,
+    WordCloudMode mode = WordCloudMode.sentence,
+    int topN = 50,
+    int minCount = 2,
+    int minLength = 2,
+    int maxLength = 200,
+  }) async {
+    if (texts.isEmpty) {
+      return WordCloudResult(
+        words: [],
+        totalUniqueCount: 0,
+        totalMessages: 0,
+      );
+    }
+
+    final counts = <String, int>{};
+
+    if (mode == WordCloudMode.sentence) {
+      // 句子模式：统计完整句子
+      for (final text in texts) {
+        final normalized = _normalizeSentence(text);
+        if (_isValidSentence(normalized, minLength, maxLength)) {
+          counts[normalized] = (counts[normalized] ?? 0) + 1;
+        }
+      }
+    } else {
+      // 词语模式：使用二元分词
+
+      for (final text in texts) {
+        final words = _tokenize(text);
+        for (final word in words) {
+          if (word.length >= minLength && !chineseStopwords.contains(word)) {
+            counts[word] = (counts[word] ?? 0) + 1;
+          }
+        }
+      }
+    }
+
+    // 排序并过滤
+    final sorted = counts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final topItems = sorted
+        .where((e) => e.value >= minCount)
+        .take(topN)
+        .map((e) => {'word': e.key, 'count': e.value})
+        .toList();
+
+    return WordCloudResult(
+      words: topItems,
+      totalUniqueCount: counts.length,
+      totalMessages: texts.length,
+    );
+  }
+
+  /// 规范化句子
+  String _normalizeSentence(String text) {
+    text = text.trim();
+    // 合并连续空白
+    text = text.replaceAll(RegExp(r'\s+'), ' ');
+    // 去除开头的 @ 提及
+    text = text.replaceAll(RegExp(r'^@\S+\s*'), '');
+    // 去除开头和结尾的方括号标记
+    text = text.replaceAll(RegExp(r'^\[.*?\]\s*'), '');
+    return text.trim();
+  }
+
+  /// 判断句子是否有效
+  bool _isValidSentence(String sentence, int minLength, int maxLength) {
+    if (sentence.isEmpty) return false;
+    if (sentence.length < minLength || sentence.length > maxLength) return false;
+
+    // === 1. 过滤系统/技术性内容 ===
+
+    // 跳过包含 wxid 的句子（通常是引用消息）
+    if (sentence.contains('wxid_') ||
+        sentence.contains('wxid:') ||
+        sentence.toLowerCase().contains('wxid')) {
+      return false;
+    }
+
+    // 跳过 XML/HTML 消息
+    if (sentence.startsWith('<?xml') ||
+        sentence.contains('<msg>') ||
+        sentence.contains('</msg>')) {
+      return false;
+    }
+    if (sentence.startsWith('<') && sentence.endsWith('>')) return false;
+
+    // 跳过 URL
+    if (RegExp(r'https?://').hasMatch(sentence)) return false;
+
+    // 跳过纯数字（电话号码、验证码等）
+    if (RegExp(r'^[\d\s\-\+]+$').hasMatch(sentence)) return false;
+
+    // === 2. 检查有意义字符比例 ===
+
+    final chineseChars = RegExp(r'[\u4e00-\u9fa5]').allMatches(sentence).length;
+    final englishChars = RegExp(r'[a-zA-Z]').allMatches(sentence).length;
+    final digits = RegExp(r'\d').allMatches(sentence).length;
+    final meaningfulChars = chineseChars + englishChars + digits;
+
+    // 只要有至少1个有意义字符即接受
+    if (meaningfulChars == 0) return false;
+
+    // === 3. 处理重复字符 ===
+
+    if (sentence.length > 2) {
+      final uniqueChars = sentence.split('').toSet();
+
+      // 只有1种字符 - 这种通常是垃圾消息
+      if (uniqueChars.length == 1) {
+        final char = uniqueChars.first;
+
+        // 如果是标点符号，过滤掉（如 "......"、"！！！"）
+        if (RegExp(r'[。，！？、\.…\-\+~～!?.,]').hasMatch(char)) {
+          return false;
+        }
+
+        // 如果是表情类字符（如 "哈哈哈哈"），保留！
+        if (_emotionalRepeatPatterns.contains(char)) {
+          return true;
+        }
+
+        // 其他单字符重复，超过5个字符就过滤（放宽条件）
+        if (sentence.length > 5) {
+          return false;
+        }
+      }
+    }
+
+    // === 4. 过滤无意义单字符 ===
+
+    final meaninglessSingleChars = {'嗯', '哦', '啊', '额', '呃', '噢', '喔', '嗷'};
+    if (sentence.length == 1 && meaninglessSingleChars.contains(sentence)) {
+      return false;
+    }
+
+    // === 5. 过滤纯表情包描述 ===
+
+    if (RegExp(r'^\[.+\]$').hasMatch(sentence)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// 分词（使用二元分词）
+  List<String> _tokenize(String text) {
+    // 使用二元分词
+    return _tokenizeBigram(text);
+  }
+
+  /// 二元分词
+  List<String> _tokenizeBigram(String text) {
+    final words = <String>[];
+
+    // 匹配中文字符块
+    final chinesePattern = RegExp(r'[\u4e00-\u9fa5]+');
+    final matches = chinesePattern.allMatches(text);
+
+    for (final match in matches) {
+      final segment = match.group(0)!;
+      if (segment.length >= 2) {
+        // 滑动窗口生成二元词组
+        for (int i = 0; i < segment.length - 1; i++) {
+          words.add(segment.substring(i, i + 2));
+        }
+      }
+    }
+
+    // 匹配英文和数字
+    final englishPattern = RegExp(r'[a-zA-Z0-9]+');
+    final englishMatches = englishPattern.allMatches(text);
+    for (final match in englishMatches) {
+      final word = match.group(0)!.toLowerCase();
+      if (word.length >= 2) {
+        words.add(word);
+      }
+    }
+
+    return words;
+  }
+
+  /// 过滤文本消息内容
+  /// 返回适合进行分析的文本列表
+  static List<String> filterTextMessages(List<String> contents) {
+    return contents
+        .where((c) => c.isNotEmpty)
+        .where((c) => !c.startsWith('['))
+        .where((c) => !c.startsWith('<?xml'))
+        .where((c) => !c.contains('<msg>'))
+        .where((c) => c.length > 1)
+        .toList();
+  }
+}

--- a/lib/widgets/annual_report/annual_report_html_renderer.dart
+++ b/lib/widgets/annual_report/annual_report_html_renderer.dart
@@ -630,7 +630,7 @@ section.page.visible .content-wrapper {
   static String _buildIntroBody(NumberFormat fmt, int friends, int messages) {
     return '''
 <div class="label-text">年度概览</div>
-<div class="hero-title">你的你的朋友们<br>互相发过</div>
+<div class="hero-title">你和你的朋友们<br>互相发过</div>
 <div class="big-stat">
   <div class="stat-num">${fmt.format(messages)}</div>
   <div class="stat-unit">条消息</div>
@@ -829,7 +829,7 @@ $heatmap
   static String _buildWordCloudBody(List words) {
     if (words.isEmpty) {
       return '''
-<div class="label-text">年度词云</div>
+<div class="label-text">年度常用语</div>
 <div class="hero-title">暂无数据</div>
 <div class="hero-desc">需要足够的文本消息才能生成</div>
 ''';
@@ -880,7 +880,7 @@ $heatmap
         .join('、');
 
     return '''
-<div class="label-text">年度词云</div>
+<div class="label-text">年度常用语</div>
 <div class="hero-title">你的年度常用语</div>
 <div class="hero-desc" style="margin-bottom: 30px;">这一年，你说得最多的是：<br><span class="hl" style="font-size: 20px;">$topThree</span></div>
 <div class="word-cloud-container">$wordItems</div>
@@ -1038,7 +1038,7 @@ $heatmap
     'activity': '作息规律',
     'midnight': '深夜好友',
     'response': '回应速度',
-    'wordcloud': '年度词云',
+    'wordcloud': '年度常用语',
     'former': '曾经的好朋友',
     'ending': '尾声'
   };

--- a/lib/widgets/annual_report/dual_report_html_renderer.dart
+++ b/lib/widgets/annual_report/dual_report_html_renderer.dart
@@ -44,6 +44,10 @@ class DualReportHtmlRenderer {
     final yearlyStats = reportData['yearlyStats'] as Map<String, dynamic>?;
     buffer.writeln(_buildSection('yearly-stats', _buildYearlyStatsBody(yearlyStats, myName, friendName, reportData['year'] as int?)));
 
+    // 第四部分：常用语（词云）
+    final wordCloudData = reportData['wordCloud'] as Map<String, dynamic>?;
+    buffer.writeln(_buildSection('word-cloud', _buildWordCloudBody(wordCloudData, myName, friendName, reportData['year'] as int?)));
+
     buffer.writeln('</main>');
 
     // JavaScript
@@ -337,6 +341,56 @@ section.page.visible .content-wrapper {
   * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }
   .main-container { scroll-snap-type: none; }
 }
+
+.word-cloud-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  padding: 30px 20px;
+  background: #FFFFFF;
+  border-radius: 20px;
+  margin: 24px 0;
+  border: 1px solid var(--line-color);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.05);
+}
+
+.word-tag {
+  display: inline-block;
+  padding: 8px 16px;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  border-radius: 20px;
+  white-space: nowrap;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: default;
+}
+
+.word-tag:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.top-phrases {
+  margin-top: 20px;
+  padding: 20px;
+  background: linear-gradient(135deg, rgba(7, 193, 96, 0.08) 0%, rgba(242, 170, 0, 0.05) 100%);
+  border-radius: 16px;
+}
+
+.top-phrases-title {
+  font-size: 14px;
+  color: #888;
+  margin-bottom: 12px;
+  letter-spacing: 1px;
+}
+
+.top-phrases-list {
+  font-size: 18px;
+  color: var(--primary);
+  font-weight: 600;
+  line-height: 1.8;
+}
 ''';
   }
 
@@ -524,6 +578,85 @@ $thisYearSection
         .replaceAll('>', '&gt;')
         .replaceAll('"', '&quot;')
         .replaceAll("'", '&#39;');
+  }
+
+  /// 构建词云部分
+  static String _buildWordCloudBody(
+    Map<String, dynamic>? wordCloudData,
+    String myName,
+    String friendName,
+    int? year,
+  ) {
+    final yearText = year != null ? '${year}年' : '历史以来';
+
+    if (wordCloudData == null) {
+      return '''
+<div class="label-text">常用语</div>
+<div class="hero-title">暂无数据</div>
+<div class="hero-desc">需要足够的文本消息才能生成</div>
+''';
+    }
+
+    final words = (wordCloudData['words'] as List?) ?? [];
+
+    if (words.isEmpty) {
+      return '''
+<div class="label-text">常用语</div>
+<div class="hero-title">暂无数据</div>
+<div class="hero-desc">需要足够的文本消息才能生成</div>
+''';
+    }
+
+    // 获取最大频率用于计算字体大小
+    final maxCount = words.isNotEmpty
+        ? ((words.first as Map)['count'] as int? ?? 1)
+        : 1;
+
+    // 构建词云标签（显示前15个）
+    final wordItems = words
+        .take(15)
+        .map((item) {
+          final sentence = _escapeHtml((item as Map)['word']?.toString() ?? '');
+          final count = (item['count'] as int?) ?? 1;
+
+          // 根据频率计算字体大小 (14px - 28px)
+          final ratio = count / maxCount;
+          final fontSize = (14 + ratio * 14).round();
+
+          // 根据频率选择颜色
+          String color;
+          if (ratio > 0.65) {
+            color = '#07C160';
+          } else if (ratio > 0.4) {
+            color = '#F2AA00';
+          } else if (ratio > 0.2) {
+            color = '#2F3437';
+          } else {
+            color = '#6B6F73';
+          }
+
+          return '''
+<span class="word-tag" style="font-size: ${fontSize}px; color: $color;" title="出现 $count 次">$sentence</span>''';
+        })
+        .join('');
+
+    // 获取前3个高频句子
+    final topThree = words
+        .take(3)
+        .map((item) => _escapeHtml((item as Map)['word']?.toString() ?? ''))
+        .join('、');
+
+    return '''
+<div class="label-text">常用语</div>
+<div class="hero-title">你们的专属口头禅</div>
+<div class="hero-desc">$yearText，你们说得最多的是：</div>
+<div class="word-cloud-container">$wordItems</div>
+<div class="top-phrases">
+  <div class="top-phrases-title">TOP 3 高频句子</div>
+  <div class="top-phrases-list">$topThree</div>
+</div>
+<div class="hero-desc" style="margin-top: 20px; font-size: 14px; color: #999;">句子越大、颜色越深，出现频率越高</div>
+''';
   }
 
 


### PR DESCRIPTION
- 移除 settings_page.dart 中的 ignore_for_file 注释和未使用的 _obscure* 字段
- 修复 chat_page.dart 和 chat_export_service.dart 中的 body_might_complete_normally_catch_error 警告
- 移除 data_management_page.dart 中多余的 unused_element_parameter 注释
- 修复年度报告中"你的你的朋友们"错别字为"你和你的朋友们"
- 将"年度词云"改为"年度常用语"
- 优化双人报告和词云服务

claude生成概述太好用了