### PR TITLE
Fix a bug of creating folders with path with 0x20 and 0x2E in trailing characters on Windows

### DIFF
--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -209,6 +209,7 @@ class AppState extends ChangeNotifier {
 
   String _sanitizePathSegment(String name) {
     var sanitized = name.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_').trim();
+    if (Platform.isWindows) sanitized = sanitized.replaceAll(RegExp(r'[ .]+$'), '').trim();
     if (sanitized.isEmpty) return '未知联系人';
     if (sanitized.length > 60) sanitized = sanitized.substring(0, 60);
     return sanitized;


### PR DESCRIPTION
Fix a bug of creating folders with path with 0x20 and 0x2E in trailing characters on Windows.
It happens when getting image paths, so this code segment is modified first.